### PR TITLE
Added the ability to Pass Formatter Options through the Controller

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -41,6 +41,10 @@ module LazyHighCharts
         </script>
       EOJS
       
+      # Remove quotes from any formatter functions
+      # Regex Reference: http://rubular.com/r/TOVnjFkkZO
+      graph.gsub!(/"formatter\":\"function(.*)}"/,'formatter: function\1}')
+
       if defined?(raw)
         return raw(graph) 
       else


### PR DESCRIPTION
See layout_helper.rb:46

There's no need to manually set formatter options in the view, these can now be passed through the controller.

Example High Chart:

```
@hc_test = LazyHighCharts::HighChart.new('graph') do |f|
  f.series(:name=>'John', :data=>[3, 20, 3, 5, 4, 10, 12 ,3, 5,6,7,7,80,9,9])
  f.series(:name=>'Jane', :data=> [1, 3, 4, 3, 3, 5, 4,-46,7,8,8,9,9,0,0,9] )
  f.options[:chart][:defaultSeriesType] = "line"    
  f.tooltip(formatter: "function() { return 'Hello World!'; }")
end
```
