### PR TITLE
Add support for passing on window.onload callbacks

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -32,7 +32,7 @@ module LazyHighCharts
 
       graph =<<-EOJS
       <script type="text/javascript">
-      function() {
+      (function() {
         var onload = window.onload;
         window.onload = function(){
           if (typeof onload == "function") onload();
@@ -41,7 +41,7 @@ module LazyHighCharts
           #{capture(&block) if block_given?}
           chart = new Highcharts.#{type}(options);
         };
-      }()
+      })()
       </script>
       EOJS
 

--- a/spec/lazy_high_charts_spec.rb
+++ b/spec/lazy_high_charts_spec.rb
@@ -28,7 +28,7 @@ describe HighChartsHelper do
     describe "ready function" do
       it "should be a javascript script" do
         high_chart(@placeholder, @chart).should have_selector('script', :type => 'text/javascript')
-        high_chart(@placeholder, @chart).should match(/}\(\)/)
+        high_chart(@placeholder, @chart).should match(/}\)\(\)/)
       end
 
       it "should assign to the onload event" do


### PR DESCRIPTION
Apologies for initially not adding a description.

This change set allows for other window.onload calls to still be carried out. It also allows for jquery to be loaded at the bottom of the page and for the generated code to still work correctly.

In short, it'll work with a standard HMTL5 best practices template, etc., without breaking anything else.
