### PR TITLE
Addresses issue #64, removing the window.onload function for AJAX requests

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -35,7 +35,7 @@ module LazyHighCharts
         chart = new Highcharts.#{type}(options);
       EOJS
 
-      if defined?(request) && request.xhr?
+      if defined?(request) && request.respond_to?(:xhr?) && request.xhr?
         graph =<<-EOJS
         <script type="text/javascript">
         (function() {


### PR DESCRIPTION
removes the window.onload javascript function for ajax requests and
simply returns the raw javascript that needs to be executed
