### PR TITLE
Added full support for arrays of hashes (e.g. yAxis)

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -67,20 +67,28 @@ module LazyHighCharts
     end
     
     private
-    
-    def generate_json_from_hash hash  
+
+    def generate_json_from_hash hash
       hash.each_pair.map do |key, value|
         k = key.to_s.camelize.gsub!(/\b\w/) { $&.downcase }
-        if value.is_a? Hash
-          %|"#{k}": { #{generate_json_from_hash(value)} }|
-        else
-          if value.respond_to?(:js_code) && value.js_code?
-            %|"#{k}": #{value}|
-          else
-            %|"#{k}": #{value.to_json}|
-          end
-        end
+        %|"#{k}": #{generate_json_from_value value}|
       end.flatten.join(',')
+    end
+
+    def generate_json_from_value value
+      if value.is_a? Hash
+        %|{ #{generate_json_from_hash value} }|
+      elsif value.is_a? Array
+        %|[ #{generate_json_from_array value} ]|
+      elsif value.respond_to?(:js_code) && value.js_code?
+        value
+      else
+        value.to_json
+      end
+    end
+
+    def generate_json_from_array array
+      array.map{|value| generate_json_from_value(value)}.join(",")
     end
     
   end


### PR DESCRIPTION
I found that I could not use formatter: %|function(){return "foo"}|.js_code within an array of axes for my combo chart - it was rendering it as a string.  I updated generate_json_from_hash in the LayoutHelper to iterate over arrays and generate the proper json and check for js_code.
