### PR TITLE
Adds support for the datetime axis type in Highcharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ Overriding entire option:
   #.....
 ````
 
+Using the datetime axis type:
+
+````
+@h = LazyHighCharts::HighChart.new('graph', style: '') do |f|
+  f.options[:chart][:defaultSeriesType] = "area"
+  f.options[:plotOptions] = {area: {pointInterval: 1.day, pointStart: 10.days.ago}}
+  f.series(:name=>'John', :data=>[3, 20, 3, 5, 4, 10, 12 ,3, 5,6,7,7,80,9,9])
+  f.series(:name=>'Jane', :data=> [1, 3, 4, 3, 3, 5, 4,-46,7,8,8,9,9,0,0,9])
+  f.xAxis(type: :datetime)
+end
+````
+A datetime axis [example](http://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/highcharts/xaxis/type-datetime/)
+
 
 Usage in layout:
 ````

--- a/lib/lazy_high_charts.rb
+++ b/lib/lazy_high_charts.rb
@@ -1,4 +1,5 @@
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts core_ext string])
+require File.join(File.dirname(__FILE__), *%w[lazy_high_charts options_key_filter])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts high_chart])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts layout_helper])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts railtie]) if defined?(::Rails::Railtie)

--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -22,7 +22,7 @@ module LazyHighCharts
     #	title:		legend: 		xAxis: 		yAxis: 		tooltip: 	credits:  :plotOptions
     def defaults_options
       self.title({ :text=>"example test title from highcharts gem"})
-      self.legend({ :layout=>"vertical", :style=>{} }) 
+      self.legend({ :layout=>"vertical", :style=>{} })
       self.xAxis({})
       self.yAxis({ :title=> {:text=> nil}, :labels=>{} })
       self.tooltip({ :enabled=>true })
@@ -48,7 +48,7 @@ module LazyHighCharts
     def series(opts = {})
       @data ||= []
       if not opts.empty?
-        @data << opts.merge(:name => opts[:name], :data => opts[:data])
+        @data << OptionsKeyFilter.filter(opts.merge(:name => opts[:name], :data => opts[:data]))
       end
     end
 

--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -24,7 +24,7 @@ module LazyHighCharts
     end
 
     def build_html_output(type, placeholder, object, &block)
-      options_collection =  [ generate_json_from_hash(object.options) ]
+      options_collection =  [ generate_json_from_hash(OptionsKeyFilter.filter(object.options)) ]
       options_collection << %|"series": [#{generate_json_from_array(object.data)}]|
 
       core_js =<<-EOJS

--- a/lib/lazy_high_charts/options_key_filter.rb
+++ b/lib/lazy_high_charts/options_key_filter.rb
@@ -1,0 +1,39 @@
+#
+# A way to filter certain keys of data provided to the LazyHighCharts#series method and the LazyHighCharts#options
+#
+# Add methods or keys to the FILTER_MAP hash to have them applied to the options in a series
+# In the FILTER_MAP, the hash keys are methods, and the values are arrays of the hash keys the filter should be
+# applied to
+#
+# Be careful that it is OK to filter the hash keys you specify for every key of the options or series hash
+#
+module LazyHighCharts
+  module OptionsKeyFilter
+    def self.milliseconds value
+      value * 1000
+    end
+
+    def self.date_to_js_code date
+      "Date.UTC(#{date.year}, #{date.month - 1}, #{date.day})".js_code
+    end
+
+    def self.filter options
+      new_options = options.map do |k, v|
+        if v.is_a? ::Hash
+          v = filter v
+        else
+          FILTER_MAP.each_pair do |method, matchers|
+            v = method.call(v) if matchers.include?(k)
+          end
+        end
+        [k, v]
+      end
+      Hash[new_options]
+    end
+
+    FILTER_MAP = {
+        method(:milliseconds) => [:pointInterval],
+        method(:date_to_js_code) => [:pointStart]
+    }
+  end
+end

--- a/spec/options_key_filter_spec.rb
+++ b/spec/options_key_filter_spec.rb
@@ -1,0 +1,28 @@
+require File.dirname(__FILE__) + '/spec_helper'
+
+describe LazyHighCharts::OptionsKeyFilter do
+  it "should filter :pointInterval from seconds to milliseconds" do
+    hash = LazyHighCharts::OptionsKeyFilter.filter(pointInterval: 1)
+    hash[:pointInterval].should == 1000
+  end
+
+  describe "filters :pointStart from a Date to a JavaScript compatible string" do
+    before(:each) do
+      hash = LazyHighCharts::OptionsKeyFilter.filter(pointStart: Date.new(2012, 9, 13))
+      @value = hash[:pointStart]
+    end
+
+    it "should be the correct string" do
+      @value.should == "Date.UTC(2012, 8, 13)"
+    end
+
+    it "should be js_code" do
+      @value.js_code.should be_true
+    end
+  end
+
+  it "should filter keys recursively" do
+    hash = LazyHighCharts::OptionsKeyFilter.filter({something: {another_thing: {pointInterval: 2}}})
+    hash[:something][:another_thing][:pointInterval].should == 2000
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require "active_support/core_ext"
 
 require File.expand_path(File.join(File.dirname(__FILE__), '../lib/lazy_high_charts'))
 require File.expand_path(File.join(File.dirname(__FILE__), '../lib/lazy_high_charts/layout_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../lib/lazy_high_charts/options_key_filter'))
 
 require 'webrat'
 require 'rspec'


### PR DESCRIPTION
Take a look at the addition to the README for an example. Created an OptionsKeyFilter module that we can easily add new filters to in case there are other keys that the Highcharts API defines that could use some help translating a ruby object to a Highcharts/JavaScript value.
