### PR TITLE
it should allow to build options step by step without overriding previously set values

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Overriding entire option:
   #.....
 ````
 
+If you want to use this syntax and still be able to build option step-by-step without overriding:
+
+````
+@h = LazyHighCharts::HighChart.new('graph') do |f|
+ #.....
+ f.xAxis!(:categories => @days.reverse! , :labels=>{:rotation=>-45 , :align => 'right'})
+ f.chart!({:defaultSeriesType=>"spline" , :renderTo => "myRenderArea" , :inverted => true})
+ #.....
+````
+
 Using the datetime axis type:
 
 ````

--- a/lazy_high_charts.gemspec
+++ b/lazy_high_charts.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = "~> 1.3"
 
   s.add_dependency "bundler", "~> 1.0"
+  s.add_dependency "hash-deep-merge"
 
   s.description = <<-DESC
     lazy_high_charts is a Rails 3.x gem for displaying Highcharts graphs.

--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -37,7 +37,11 @@ module LazyHighCharts
     #
     # For instance: <tt>high_chart.grid(:color => "#699")</tt>
     def method_missing(meth, opts = {})
-      merge_options meth, opts
+      if meth.to_s.end_with? '!'
+        deep_merge_options meth[0..-2].to_sym, opts
+      else
+        merge_options meth, opts
+      end
     end
 
     # Add a simple series to the graph:
@@ -60,6 +64,10 @@ private
 
     def merge_options(name, opts)
       @options.merge!  name => opts
+    end
+
+    def deep_merge_options(name, opts)
+      @options.deep_merge!  name => opts
     end
 
     def arguments_to_options(args)

--- a/spec/high_chart_spec.rb
+++ b/spec/high_chart_spec.rb
@@ -104,6 +104,24 @@ describe "HighChart" do
         end
        chart.options[:subtitle][:text].should == "Bar"
     end
+
+    it 'should override entire option by default when resetting it again' do
+      chart = LazyHighCharts::HighChart.new('graph') do |f|
+        f.xAxis(categories: [3, 5, 7])
+        f.xAxis(title: {text: 'x title'})
+      end
+      chart.options[:xAxis][:categories].should == nil
+      chart.options[:xAxis][:title][:text].should == 'x title'
+    end
+
+    it 'should allow to build options step by step without overriding previously set values' do
+      chart = LazyHighCharts::HighChart.new('graph') do |f|
+        f.xAxis!(categories: [3, 5, 7])
+        f.xAxis!(title: {text: 'x title'})
+      end
+      chart.options[:xAxis][:categories].should == [3, 5, 7]
+      chart.options[:xAxis][:title][:text].should == 'x title'
+    end
      
   end
 


### PR DESCRIPTION
See added specs.

I know I could use

```
f.options[:xAxis][:categories] = [3, 5, 7]
f.options[:xAxis][:title][:text] = 'x title' 
```

But then I have to be sure that all "middle-hashes" are already initialized and I am not calling []= on nil.
