### PR TITLE
Can be used without rails

### DIFF
--- a/lib/lazy_high_charts.rb
+++ b/lib/lazy_high_charts.rb
@@ -2,8 +2,10 @@ require File.join(File.dirname(__FILE__), *%w[lazy_high_charts core_ext string])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts options_key_filter])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts high_chart])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts layout_helper])
-require File.join(File.dirname(__FILE__), *%w[lazy_high_charts railtie])
-require File.join(File.dirname(__FILE__), *%w[lazy_high_charts engine]) if ::Rails.version >= '3.1'
+if defined?(::Rails::Railtie)
+  require File.join(File.dirname(__FILE__), *%w[lazy_high_charts railtie])
+  require File.join(File.dirname(__FILE__), *%w[lazy_high_charts engine]) if ::Rails.version >= '3.1'
+end
 
 module LazyHighCharts
 


### PR DESCRIPTION
I'm using this gem as a dependency to other gem (https://github.com/tomgi/git_stats) without requiring rails. It doesn't work since https://github.com/tomgi/lazy_high_charts/commit/6e82d67034037bb4b3c72e2f4de9221eb2731df7#L5L5
Restored check for `defined?(::Rails::Railtie)`
