### PR TITLE
Fix Turbolinks support and eliminate jQuery dependency

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -45,19 +45,11 @@ module LazyHighCharts
         graph =<<-EOJS
         <script type="text/javascript">
         (function() {
-          $(window).bind('page:load', function() {
+          var f = function(){
+            document.removeEventListener('page:load', f, true);
             #{core_js}
-          });
-        })()
-        </script>
-        EOJS
-      elsif defined?(Turbolinks) && request.headers["X-XHR-Referer"]
-        graph =<<-EOJS
-        <script type="text/javascript">
-        (function() {
-          $(window).bind('page:load', function() {
-            #{core_js}
-          });
+          };
+          document.addEventListener('page:load', f, true);
         })()
         </script>
         EOJS


### PR DESCRIPTION
- Removes the duplicate Turbolinks condition from the `if` statement
- Binds to the `page:load` event without using jQuery
- Fixes Turbolinks support by removing the callback after one execution
