### PR TITLE
Gemfile sources https://rubygems.org not http://ruby.taobao.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://ruby.taobao.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in lazy_high_charts.gemspec
 gemspec


### PR DESCRIPTION
This alternate source crept in e0a39481180cda072ba2c0e64b275661e96d61f3, presumably by accident.

This is currently causing Travis build to fail, as the alternate gem source doesn't have ZenTest-4.9.0 available:
https://travis-ci.org/michelson/lazy_high_charts/builds/5146715

It's also a terrible security risk, especially in light of the RubyGems.org compromise earlier this year.
