### PR TITLE
Travis CI configured; upgrades RubyGems version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+
+rvm:
+  - 1.9.3
+
+before_install:
+  - gem update --system
+  - gem --version


### PR DESCRIPTION
The current version of ZenTest breaks on the current verison of
RubyGems that ships with Ruby 1.9.3 on Travis.

This Travis config causes a `gem update --system`.

```
$ travis-lint
Hooray, lazy_high_charts/.travis.yml seems to be solid!
```

See:
http://about.travis-ci.org/docs/user/languages/ruby/#Upgrading-RubyGems
