### PR TITLE
Gemfile (:test, :development) specifies Rails 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec
 group :test, :development do # This causes the plugins to NOT load
   gem 'webrat','~> 0.7'
   gem 'rspec', '~> 2.0'
-  gem 'rails'
+  gem 'rails', "~> 3.0"
   gem 'autotest'
 end


### PR DESCRIPTION
Without this specification, rails 2.3 was being installed by default.

```
$ ruby --version ruby 1.9.3p385 (2013-02-06 revision 39114)
[x86_64-darwin12.2.0]

$ gem --version 2.0.3

$ bundle --version Bundler version 1.3.3
```
