### PR TITLE
Add #to_s method to VERSION modules

### DIFF
--- a/lib/lazy_high_charts.rb
+++ b/lib/lazy_high_charts.rb
@@ -4,7 +4,7 @@ require File.join(File.dirname(__FILE__), *%w[lazy_high_charts high_chart])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts layout_helper])
 if defined?(::Rails::Railtie)
   require File.join(File.dirname(__FILE__), *%w[lazy_high_charts railtie])
-  require File.join(File.dirname(__FILE__), *%w[lazy_high_charts engine]) if ::Rails.version >= '3.1'
+  require File.join(File.dirname(__FILE__), *%w[lazy_high_charts engine]) if ::Rails.version.to_s >= '3.1'
 end
 
 module LazyHighCharts


### PR DESCRIPTION
Needed to work with edge rails, due to this change: https://github.com/rails/rails/pull/8501
similar to this issue for jquery-rails: https://github.com/rails/jquery-rails/commit/b546434a2dba7061cb658ba5d302bfc37ceb2e2f
