### PR TITLE
Default to a usable random placeholder

### DIFF
--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -14,7 +14,7 @@ module LazyHighCharts
         high_chart.options    ||= {}
         high_chart.defaults_options
         high_chart.html_options ||= html_opts
-        high_chart.canvas       = canvas if canvas
+        high_chart.canvas = (canvas ? canvas : random_canvas_id)
         yield high_chart if block_given?
       end
     end
@@ -57,6 +57,12 @@ module LazyHighCharts
     end
 
 private
+
+    def random_canvas_id
+      canvas_id_length = 11
+# Don't use SecureRandom.urlsafe_base64; it gives invalid characters.
+      ('a'..'z').to_a.shuffle.take(canvas_id_length).join
+    end
 
     def series_options
       @options.reject {|k,v| SERIES_OPTIONS.include?(k.to_s) == false}

--- a/spec/high_chart_spec.rb
+++ b/spec/high_chart_spec.rb
@@ -18,7 +18,16 @@ describe "HighChart" do
   describe "initialization" do
     it "should take an optional 'placeholder' argument" do
       LazyHighCharts::HighChart.new(@placeholder).placeholder.should == @placeholder
-      LazyHighCharts::HighChart.new.placeholder.should == nil
+      LazyHighCharts::HighChart.new.placeholder.should_not == @placeholder
+    end
+
+    it "shouldn't generate a nil placeholder" do
+      LazyHighCharts::HighChart.new.placeholder.should_not be_nil
+    end
+
+    it "should generate different placeholders for different charts" do
+      a_different_placeholder = LazyHighCharts::HighChart.new.placeholder
+      LazyHighCharts::HighChart.new.placeholder.should_not == a_different_placeholder
     end
 
     it "should take an optional html_options argument (defaulting to 300px height)" do


### PR DESCRIPTION
Includes tests; all tests pass (on Ruby 2.0.0).

By default, generate usable random placeholders instead of nil. Thus, differing placeholders (canvas ID's) are generated automatically. This eases having multiple charts on a page.

So, it enables easier coding like this:

``` ruby
chart1 = LazyHighCharts::HighChart.new
chart2 = LazyHighCharts::HighChart.new
# Code to set chart options here.
high_chart(chart1.canvas, chart1)
high_chart(chart2.canvas, chart2)
```
