### PR TITLE
HighChart#to_ary returns a Hash

### DIFF
--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -39,6 +39,10 @@ module LazyHighCharts
     #
     # For instance: <tt>high_chart.grid(:color => "#699")</tt>
     def method_missing(meth, opts = {})
+      if meth.to_s == 'to_ary'
+        super
+      end
+
       if meth.to_s.end_with? '!'
         deep_merge_options meth[0..-2].to_sym, opts
       else

--- a/spec/high_chart_spec.rb
+++ b/spec/high_chart_spec.rb
@@ -149,4 +149,11 @@ describe "HighChart" do
 
   end
 
+  describe '#to_ary' do
+    subject { LazyHighCharts::HighChart.new }
+
+    it 'raises NoMethodError' do
+      expect { subject.to_ary }.to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
I fixed it by calling super when the name of the method is 'to_ary'.
