### PR TITLE
added feature to set global options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# VERSION 1.5.5
+  * Mon Oct 19, 2015
+    1. Support for HighChart global settings.
+    [#149](https://github.com/michelson/lazy_high_charts/issues/149)
+    2. Minor code refactorings.
+
 # VERSION 1.5.4
   * Fri May 21
     1. Include ActionView::Helpers::TagHelper to the layout helper to avoid method conflict in object.
@@ -5,14 +11,14 @@
 # VERSION 1.5.3
   * Fri Apr 18
     1. update HighChart js lib to latest.
-    
+
 # VERSION 1.5.2
   * Sun Mar 11, 2014
     1. Merge some requirement tweaks to use gem in NON-Rails contexts
 
 # VERSION 1.5.1
   * Sun Dec 22, 2013
-    1. Share highcharts:update rake task for gem and rails host app 
+    1. Share highcharts:update rake task for gem and rails host app
 
 # VERSION 1.5.0
   * Sun Jul 21, 2013

--- a/README.md
+++ b/README.md
@@ -62,25 +62,47 @@ to install it.
 ### Controller code:
 ```ruby
 @chart = LazyHighCharts::HighChart.new('graph') do |f|
-  f.title(:text => "Population vs GDP For 5 Big Countries [2009]")
-  f.xAxis(:categories => ["United States", "Japan", "China", "Germany", "France"])
-  f.series(:name => "GDP in Billions", :yAxis => 0, :data => [14119, 5068, 4985, 3339, 2656])
-  f.series(:name => "Population in Millions", :yAxis => 1, :data => [310, 127, 1340, 81, 65])
+  f.title(text: "Population vs GDP For 5 Big Countries [2009]")
+  f.xAxis(categories: ["United States", "Japan", "China", "Germany", "France"])
+  f.series(name: "GDP in Billions", yAxis: 0, data: [14119, 5068, 4985, 3339, 2656])
+  f.series(name: "Population in Millions", yAxis: 1, data: [310, 127, 1340, 81, 65])
 
   f.yAxis [
-    {:title => {:text => "GDP in Billions", :margin => 70} },
-    {:title => {:text => "Population in Millions"}, :opposite => true},
+    {title: {text: "GDP in Billions", margin: 70} },
+    {title: {text: "Population in Millions"}, opposite: true},
   ]
 
-  f.legend(:align => 'right', :verticalAlign => 'top', :y => 75, :x => -50, :layout => 'vertical',)
-  f.chart({:defaultSeriesType=>"column"})
+  f.legend(align: 'right', verticalAlign: 'top', y: 75, x: -50, layout: 'vertical')
+  f.chart({defaultSeriesType: "column"})
+end
+
+@chart_globals = LazyHighCharts::HighChartGlobals.new do |f|
+  f.global(useUTC: false)
+  f.chart(
+    backgroundColor: {
+      linearGradient: [0, 0, 500, 500],
+      stops: [
+        [0, "rgb(255, 255, 255)"],
+        [1, "rgb(240, 240, 255)"]
+      ]
+    },
+    borderWidth: 2,
+    plotBackgroundColor: "rgba(255, 255, 255, .9)",
+    plotShadow: true,
+    plotBorderWidth: 1
+  )
+  f.lang(thousandsSep: ",")
+  f.colors(["#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354"])
 end
 ```
 
 ### View Helpers:
 ```ruby
+<%= high_chart_globals(@chart_globals) %>
 <%= high_chart("some_id", @chart) %>
 ```
+
+`high_chart_globals` is optional. Use it to set the global options of all charts that are currently displayed on the page. More info [here](http://api.highcharts.com/highcharts#global).
 
 ###Demo projects:
 

--- a/lib/lazy_high_charts.rb
+++ b/lib/lazy_high_charts.rb
@@ -5,6 +5,7 @@ require File.join(File.dirname(__FILE__), *%w[lazy_high_charts core_ext string])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts options_key_filter])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts layout_helper])
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts high_chart])
+require File.join(File.dirname(__FILE__), *%w[lazy_high_charts high_chart_globals])
 if defined?(::Rails::Railtie)
   require File.join(File.dirname(__FILE__), *%w[lazy_high_charts railtie])
   require File.join(File.dirname(__FILE__), *%w[lazy_high_charts engine]) if ::Rails.version.to_s >= '3.1'

--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -34,7 +34,6 @@ module LazyHighCharts
       self.subtitle({})
     end
 
-
     # Pass other methods through to the javascript high_chart object.
     #
     # For instance: <tt>high_chart.grid(:color => "#699")</tt>

--- a/lib/lazy_high_charts/high_chart_globals.rb
+++ b/lib/lazy_high_charts/high_chart_globals.rb
@@ -1,0 +1,29 @@
+module LazyHighCharts
+  class HighChartGlobals
+  	include LayoutHelper
+
+  	attr_accessor :options
+
+  	def initialize
+  	  self.tap do |chart_globals|
+        chart_globals.options ||= {}
+        yield chart_globals if block_given?
+      end
+  	end
+
+  	# Pass other methods through to the high_chart_globals object.
+    #
+    # For instance: <tt>high_chart_globals.global(:useUTC => false)</tt>
+    def method_missing(meth, opts = {})
+      if meth.to_s == 'to_ary'
+        super
+      end
+      merge_options meth, opts      
+    end
+
+    def merge_options(name, opts)
+      @options.merge! name => opts
+    end
+
+  end
+end

--- a/spec/high_chart_globals_spec.rb
+++ b/spec/high_chart_globals_spec.rb
@@ -1,0 +1,51 @@
+require File.dirname(__FILE__) + '/spec_helper'
+
+describe "HighChartGlobals" do
+  before(:each) do
+    @chart_globals = LazyHighCharts::HighChartGlobals.new do |chart|
+      chart.global( useUTC: false )
+      chart.chart(
+        backgroundColor: {
+          linearGradient: [0, 0, 500, 500],
+          stops: [
+            [0, "rgb(255, 255, 255)"],
+            [1, "rgb(240, 240, 255)"]
+          ]
+        },
+        borderWidth: 2,
+        plotBackgroundColor: "rgba(255, 255, 255, .9)",
+        plotShadow: true,
+        plotBorderWidth: 1
+      )
+      chart.lang(
+        thousandsSep: ","
+      )
+      chart.colors([
+        "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354"
+      ])
+    end
+  end
+
+  # this is almost all flotomatic stuff
+  describe "initialization" do
+
+    it "should set options hash by default" do
+      @chart_globals.options.is_a?(Hash).should == true
+    end
+
+    it "should take a block and set attributes" do
+      @chart_globals.options[:lang][:thousandsSep].should == ","
+      @chart_globals.options[:global][:useUTC].should == false
+      @chart_globals.options[:chart][:backgroundColor][:linearGradient].should == [0, 0, 500, 500]
+    end
+
+    it "should override options" do
+      chart = LazyHighCharts::HighChartGlobals.new
+      chart.global({ useUTC: true })
+      chart.options[:global][:useUTC].should == true
+      chart.global({ useUTC: false })
+      chart.options[:global][:useUTC].should == false
+    end
+
+  end
+end

--- a/spec/lazy_high_charts_spec.rb
+++ b/spec/lazy_high_charts_spec.rb
@@ -10,6 +10,28 @@ describe HighChartsHelper do
     @chart = LazyHighCharts::HighChart.new(@placeholder)
     @data = "data"
     @options = "options"
+    @chart_globals = LazyHighCharts::HighChartGlobals.new do |chart|
+      chart.global({ useUTC: false })
+      chart.chart({
+        backgroundColor: {
+          linearGradient: [0, 0, 500, 500],
+          stops: [
+            [0, "rgb(255, 255, 255)"],
+            [1, "rgb(240, 240, 255)"]
+          ]
+        },
+        borderWidth: 2,
+        plotBackgroundColor: "rgba(255, 255, 255, .9)",
+        plotShadow: true,
+        plotBorderWidth: 1
+      })
+      chart.lang({
+        thousandsSep: ","
+      })
+      chart.colors([
+        "#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354"
+      ])
+    end
   end
 
   context "layout_helper" do
@@ -20,6 +42,18 @@ describe HighChartsHelper do
     it "should return a script" do
       hc = LazyHighCharts::HighChart.new("placeholder")
       expect(high_chart(hc.placeholder, hc)).to have_selector('script')
+    end
+  end
+
+  context "high_chart_globals" do
+    it "should return a script" do
+      high_chart_globals(@chart_globals).should have_selector('script')
+    end
+
+    it "should take a block and set attributes" do
+      high_chart_globals(@chart_globals).should match(/useUTC/)
+      high_chart_globals(@chart_globals).should match(/backgroundColor/)
+      high_chart_globals(@chart_globals).should match(/thousandsSep/)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'active_support'
 require 'action_pack'
 require 'action_view'
 require 'action_controller'
-require "active_support/core_ext"
+require 'active_support/core_ext'
 
 
 require File.expand_path(File.join(File.dirname(__FILE__), '../lib/lazy_high_charts'))


### PR DESCRIPTION
My attempt at incorporating HighChart global options. Resolves #149. 

Option can be set in the controller with:

```ruby
@chart_globals = LazyHighCharts::HighChartGlobals.new do |f|
  f.global(useUTC: false)
  f.lang(thousandsSep: ",")
  f.colors(["#90ed7d", "#f7a35c", "#8085e9", "#f15c80", "#e4d354"])
end
```

Then printed in the view:
```ruby
<%= high_chart_globals @chart_globals %>
```