### PR TITLE
Include ActionView::Helpers::TagHelper to the layout helper.

### DIFF
--- a/lib/lazy_high_charts.rb
+++ b/lib/lazy_high_charts.rb
@@ -1,5 +1,4 @@
 require 'action_view'
-include ActionView::Helpers::TagHelper
 require 'json'
 
 require File.join(File.dirname(__FILE__), *%w[lazy_high_charts core_ext string])

--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -2,6 +2,7 @@
 
 module LazyHighCharts
   module LayoutHelper
+    include ActionView::Helpers::TagHelper
 
     def high_chart(placeholder, object, &block)
       object.html_options.merge!({:id => placeholder})


### PR DESCRIPTION
Including ActionView::Helpers::TagHelper to Object looks like bad practice. Object is polluted with helper methods. It introduces bugs if classes of an application have method names that conflict with the methods of ActionView::Helpers::TagHelper.

I encountered the issue when tested specs using FactoryGirl (see "tag" in code below):

```
factory :page do
    ignore do
      tag 'a tag'
    end

    tags { [tag] }
    ...
```
