### PR TITLE
DRY up creation of JSON string

### DIFF
--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -66,11 +66,7 @@ module LazyHighCharts
     #
     # @return [Hash] options JSON options hash
     def full_options
-      options_collection = [generate_json_from_hash(OptionsKeyFilter.filter(self.options))]
-      options_collection << %|"series": [#{generate_json_from_array(self.series_data)}]|
-      <<-EOJS
-      { #{options_collection.join(', ')} }
-      EOJS
+      options_collection_as_string self
     end
 
     def to_json

--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -25,11 +25,8 @@ module LazyHighCharts
     end
 
     def build_html_output(type, placeholder, object, &block)
-      options_collection = [generate_json_from_hash(OptionsKeyFilter.filter(object.options))]
-      options_collection << %|"series": [#{generate_json_from_array(object.series_data)}]|
-
       core_js =<<-EOJS
-        var options = { #{options_collection.join(',')} };
+        var options = #{options_collection_as_string(object)};
         #{capture(&block) if block_given?}
         window.chart_#{placeholder.underscore} = new Highcharts.#{type}(options);
       EOJS
@@ -107,6 +104,12 @@ module LazyHighCharts
 
     def request_is_referrer?
       defined?(request) && request.respond_to?(:headers) && request.headers["X-XHR-Referer"]
+    end
+
+    def options_collection_as_string object
+      options_collection = [generate_json_from_hash(OptionsKeyFilter.filter(object.options))]
+      options_collection << %|"series": [#{generate_json_from_array(object.series_data)}]|
+      "{ #{options_collection.join(',')} }"
     end
   end
 end


### PR DESCRIPTION
The former used self.data which is always undefined because the object uses
seires_data instead. layout_helper knew about this but high_chart did not?

Anyway, DRY the logic so it isn't repeated which fixes this problem.