### PR TITLE
Add HighChart#as_json method

### DIFF
--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -73,6 +73,12 @@ module LazyHighCharts
       EOJS
     end
 
+    def to_json
+      data = self.options.clone
+      data[:series] = self.series_data.clone
+      data
+    end
+
     private
 
     def random_canvas_id


### PR DESCRIPTION
When using a HighChart object for returning JSON data in a rails controller it
is often appropiot to pass an object into the render method as a hash to be
converted into JSON.

    render json: @chart

The render method will process the hash offered by the json: using it's 
as_json method if it exists.

http://stackoverflow.com/a/2574900/227176 explains this better.