### PR TITLE
Remove unused block argument

### DIFF
--- a/lib/lazy_high_charts/high_chart.rb
+++ b/lib/lazy_high_charts/high_chart.rb
@@ -82,7 +82,7 @@ module LazyHighCharts
     end
 
     def series_options
-      @options.reject { |k, v| SERIES_OPTIONS.include?(k.to_s) == false }
+      @options.reject { |k, _| SERIES_OPTIONS.include?(k.to_s) == false }
     end
 
     def merge_options(name, opts)


### PR DESCRIPTION
Since object hashes require both variables, we can designate this local variable with `_` so we know that the value portion is not used
