### PR TITLE
revamped the OptionsKeyFilter class

### DIFF
--- a/lib/lazy_high_charts/options_key_filter.rb
+++ b/lib/lazy_high_charts/options_key_filter.rb
@@ -1,39 +1,42 @@
-#
 # A way to filter certain keys of data provided to the LazyHighCharts#series method and the LazyHighCharts#options
 #
-# Add methods or keys to the FILTER_MAP hash to have them applied to the options in a series
-# In the FILTER_MAP, the hash keys are methods, and the values are arrays of the hash keys the filter should be
-# applied to
+# Add keys and methods to the FILTER_MAP hash to have them applied to the options in a series
 #
 # Be careful that it is OK to filter the hash keys you specify for every key of the options or series hash
 #
 module LazyHighCharts
   module OptionsKeyFilter
-    def self.milliseconds value
-      value * 1000
-    end
+    FILTER_MAP = {
+      pointInterval: [:milliseconds],
+      pointStart: [:date_to_js_code]
+    }
 
-    def self.date_to_js_code date
-      "Date.UTC(#{date.year}, #{date.month - 1}, #{date.day})".js_code
-    end
+    class << self
+      def filter options
+        {}.tap do |hash|
+          options.each do |key, value|
+            if value.is_a?(::Hash)
+              hash[key] = filter(value)
+            elsif methods = FILTER_MAP[key]
+              methods.each do |method_name|
+                value = send(method_name, value)
+              end
 
-    def self.filter options
-      new_options = options.map do |k, v|
-        if v.is_a? ::Hash
-          v = filter v
-        else
-          FILTER_MAP.each_pair do |method, matchers|
-            v = method.call(v) if matchers.include?(k)
+              hash[key] = value
+            end
           end
         end
-        [k, v]
       end
-      Hash[new_options]
-    end
 
-    FILTER_MAP = {
-        method(:milliseconds) => [:pointInterval],
-        method(:date_to_js_code) => [:pointStart]
-    }
+      private
+
+      def milliseconds value
+        value * 1_000
+      end
+
+      def date_to_js_code date
+        "Date.UTC(#{date.year}, #{date.month - 1}, #{date.day})".js_code
+      end
+    end
   end
 end

--- a/lib/lazy_high_charts/options_key_filter.rb
+++ b/lib/lazy_high_charts/options_key_filter.rb
@@ -19,9 +19,7 @@ module LazyHighCharts
               hash[key] = filter(value)
             else
               hash[key] = value
-
               methods = Array(FILTER_MAP[key])
-
               methods.each do |method_name|
                 hash[key] = send(method_name, hash[key])
               end

--- a/lib/lazy_high_charts/options_key_filter.rb
+++ b/lib/lazy_high_charts/options_key_filter.rb
@@ -7,8 +7,8 @@
 module LazyHighCharts
   module OptionsKeyFilter
     FILTER_MAP = {
-      pointInterval: [:milliseconds],
-      pointStart: [:date_to_js_code]
+      :pointInterval => [:milliseconds],
+      :pointStart => [:date_to_js_code]
     }
 
     class << self
@@ -17,12 +17,14 @@ module LazyHighCharts
           options.each do |key, value|
             if value.is_a?(::Hash)
               hash[key] = filter(value)
-            elsif methods = FILTER_MAP[key]
-              methods.each do |method_name|
-                value = send(method_name, value)
-              end
-
+            else
               hash[key] = value
+
+              methods = Array(FILTER_MAP[key])
+
+              methods.each do |method_name|
+                hash[key] = send(method_name, hash[key])
+              end
             end
           end
         end

--- a/spec/lazy_high_charts_spec.rb
+++ b/spec/lazy_high_charts_spec.rb
@@ -72,11 +72,13 @@ describe HighChartsHelper do
         expect(high_chart(@placeholder, @chart)).to match(/if \(typeof onload == "function"\)\s*onload\(\)/)
       end
     end
+
     describe "initialize HighChart" do
       it "should set variables `chart` `options`" do
         expect(high_chart(@placeholder, @chart)).to match(/var\s+options\s+=/)
         expect(high_chart(@placeholder, @chart)).to match(/window.chart_placeholder\s=/)
       end
+
       it "should set Chart data" do
         expect(high_chart(@placeholder, @chart)).to match(/window\.chart_placeholder\s=\snew\sHighcharts.Chart/)
       end

--- a/spec/lazy_high_charts_spec.rb
+++ b/spec/lazy_high_charts_spec.rb
@@ -72,13 +72,11 @@ describe HighChartsHelper do
         expect(high_chart(@placeholder, @chart)).to match(/if \(typeof onload == "function"\)\s*onload\(\)/)
       end
     end
-
     describe "initialize HighChart" do
       it "should set variables `chart` `options`" do
         expect(high_chart(@placeholder, @chart)).to match(/var\s+options\s+=/)
         expect(high_chart(@placeholder, @chart)).to match(/window.chart_placeholder\s=/)
       end
-
       it "should set Chart data" do
         expect(high_chart(@placeholder, @chart)).to match(/window\.chart_placeholder\s=\snew\sHighcharts.Chart/)
       end


### PR DESCRIPTION
* opted for `class << self` instead of `def self.`
* restricted access to methods that should be private
* redesigned the `FILTER_MAP` constant to hold simple symbols and arrays rather than method objects
* rewrote the `filter` method to create and populate a hash in a more readable way than before
* replaced `1000` with `1_000` as is often suggested by ruby style guides

Note that there are already proper tests setup for the mentioned class.