### PR TITLE
Support for Turbolinks 5

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -94,7 +94,7 @@ module LazyHighCharts
         js_output =<<-EOJS
         #{js_start}
           var f = function(){
-            document.removeEventListener('page:load', f, true);
+            document.removeEventListener('#{Turbolinks::VERSION.first.to_i < 5 ? 'page:load' : 'turbolinks:load'}', f, true);
             #{core_js}
           };
           document.addEventListener('page:load', f, true);


### PR DESCRIPTION
Turbolinks V5 calls `turbolinks:load` instead of `page:load`

https://github.com/michelson/lazy_high_charts/pull/95