### PR TITLE
Change lazy high charts rake file to download modules/funnel.js

### DIFF
--- a/lib/tasks/high_charts.rake
+++ b/lib/tasks/high_charts.rake
@@ -15,10 +15,11 @@ namespace :highcharts do
     say "Grabbing Core from Highcharts codebase..." do
       sh "mkdir -p vendor/assets/javascripts/highcharts/modules/"
       sh "mkdir -p vendor/assets/javascripts/highcharts/adapters/"
-      
+
       sh "curl -# http://code.highcharts.com/highcharts.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts.js"
       sh "curl -# http://code.highcharts.com/highcharts-more.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts-more.js"
       sh "curl -# http://code.highcharts.com/modules/exporting.js -L --compressed -o vendor/assets/javascripts/highcharts/modules/exporting.js"
+      sh "curl -# http://code.highcharts.com/modules/funnel.js -L --compressed -o vendor/assets/javascripts/highcharts/modules/funnel.js"
       sh "curl -# http://code.highcharts.com/adapters/mootools-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/adapters/mootools-adapter.js"
       sh "curl -# http://code.highcharts.com/adapters/prototype-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/adapters/prototype-adapter.js"
     end
@@ -33,6 +34,7 @@ namespace :highcharts do
       sh "curl -# http://code.highcharts.com/stock/highstock.js -L --compressed -o vendor/assets/javascripts/highcharts/highstock.js"
       sh "curl -# http://code.highcharts.com/stock/highcharts-more.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/highcharts-more.js"
       sh "curl -# http://code.highcharts.com/stock/modules/exporting.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/modules/exporting.js"
+      sh "curl -# http://code.highcharts.com/stock/modules/funnel.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/modules/funnel.js"
       sh "curl -# http://code.highcharts.com/stock/adapters/mootools-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/adapters/mootools-adapter.js"
       sh "curl -# http://code.highcharts.com/stock/adapters/prototype-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/adapters/prototype-adapter.js"
     end


### PR DESCRIPTION
Hi!

I added a line in the rake file to download modules/funnel.js (it's needed for pyramid graphs for instance).

Cheers,
 Sciamp