### PR TITLE
Add fetching line for /modules/funnel.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ bundler_args: --without production development
 script: bundle exec rake
 
 rvm:
-  - 2.2.3
+  - 2.2.5

--- a/lib/tasks/high_charts.rake
+++ b/lib/tasks/high_charts.rake
@@ -15,10 +15,11 @@ namespace :highcharts do
     say "Grabbing Core from Highcharts codebase..." do
       sh "mkdir -p vendor/assets/javascripts/highcharts/modules/"
       sh "mkdir -p vendor/assets/javascripts/highcharts/adapters/"
-      
+
       sh "curl -# http://code.highcharts.com/highcharts.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts.js"
       sh "curl -# http://code.highcharts.com/highcharts-more.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts-more.js"
       sh "curl -# http://code.highcharts.com/modules/exporting.js -L --compressed -o vendor/assets/javascripts/highcharts/modules/exporting.js"
+      sh "curl -# http://code.highcharts.com/modules/funnel.js -L --compressed -o vendor/assets/javascripts/highcharts/modules/funnel.js"
       sh "curl -# http://code.highcharts.com/adapters/mootools-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/adapters/mootools-adapter.js"
       sh "curl -# http://code.highcharts.com/adapters/prototype-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/adapters/prototype-adapter.js"
     end
@@ -29,10 +30,11 @@ namespace :highcharts do
 
       sh "mkdir -p vendor/assets/javascripts/highcharts/stock/modules/"
       sh "mkdir -p vendor/assets/javascripts/highcharts/stock/adapters/"
-      
+
       sh "curl -# http://code.highcharts.com/stock/highstock.js -L --compressed -o vendor/assets/javascripts/highcharts/highstock.js"
       sh "curl -# http://code.highcharts.com/stock/highcharts-more.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/highcharts-more.js"
       sh "curl -# http://code.highcharts.com/stock/modules/exporting.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/modules/exporting.js"
+      sh "curl -# http://code.highcharts.com/stock/modules/funnel.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/modules/funnel.js"
       sh "curl -# http://code.highcharts.com/stock/adapters/mootools-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/adapters/mootools-adapter.js"
       sh "curl -# http://code.highcharts.com/stock/adapters/prototype-adapter.js -L --compressed -o vendor/assets/javascripts/highcharts/stock/adapters/prototype-adapter.js"
     end


### PR DESCRIPTION
Change the rake task to download modules/funnel.js.

I also changed the ruby version as required by the CI.

Cheers,
Sciamp