### PR TITLE
IRuby.display works now for high_chart

### DIFF
--- a/lazy_high_charts.gemspec
+++ b/lazy_high_charts.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3"
 
   s.add_development_dependency "bundler", ">= 1.0"
+  s.add_development_dependency "iruby"
   s.add_dependency "hash-deep-merge"
 
   s.description = <<-DESC

--- a/lib/lazy_high_charts.rb
+++ b/lib/lazy_high_charts.rb
@@ -15,4 +15,57 @@ module LazyHighCharts
   def self.root
     File.expand_path '../..', __FILE__
   end
+
+  @@dep_libraries = {
+    # jquery: 'https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
+    highcharts: 'http://code.highcharts.com/highcharts.js'
+  }
+  @@additional_libraries = {}
+
+  # Load extension library to IRuby notebook after Nyaplotjs is loaded
+  def self.add_dependency(name, url)
+    @@dep_libraries[name]=url;
+  end
+
+  # Load extension library to IRuby notebook before Nyaplotjs is loaded
+  def self.add_additional_library(name, url)
+    @@additional_libraries[name]=url
+  end
+
+  # generate initializing code
+  def self.generate_init_code(assets=:inline)
+    dep_libraries = @@dep_libraries
+    additional_libraries = @@additional_libraries
+    js_dir = File.expand_path("../../vendor/assets/javascripts/highcharts", __FILE__)
+    case assets
+    when :cdn
+      path = File.expand_path("../templates/init.cdn.js.erb", __FILE__)
+    when :inline
+      path = File.expand_path("../templates/init.inline.js.erb", __FILE__)
+    end
+    template = File.read(path)
+    ERB.new(template).result(binding)
+  end
+
+  # Enable to show plots on IRuby notebook
+  def self.init_iruby
+    js = self.generate_init_code
+    IRuby.display(IRuby.javascript(js))
+  end
+
+  def self.load_notebook(assets=:inline)
+    init_code = generate_init_code
+    case assets
+    when :cdn
+      IRuby.display(IRuby.javascript(init_code))
+    when :inline
+      IRuby.display(IRuby.html(<<END_HTML))
+<script type="application/javascript">
+#{init_code}
+</script>
+END_HTML
+    end
+    true
+  end
+  self.init_iruby if defined? IRuby
 end

--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -10,6 +10,10 @@ module LazyHighCharts
       high_graph(placeholder, object, &block).concat(content_tag("div", "", object.html_options))
     end
 
+    def high_chart_iruby(placeholder, object, &block)
+      IRuby.html(high_chart(placeholder, object, &block))
+    end
+
     def high_stock(placeholder, object, &block)
       object.html_options.merge!({:id => placeholder})
       object.options[:chart][:renderTo] = placeholder

--- a/lib/templates/init.cdn.js.erb
+++ b/lib/templates/init.cdn.js.erb
@@ -1,0 +1,47 @@
+if(window['jquery'] === undefined ||
+   window['highcharts'] === undefined){
+    var path = <%= dep_libraries.merge(additional_libraries).to_json %>;
+
+<%
+shim = dep_libraries.merge(additional_libraries).inject({}){|hash, (k, v)| hash[k]={exports: k};next hash}
+%>
+
+    var shim = <%= shim.to_json %>;
+
+    require.config({paths: path, shim:shim});
+
+<%
+str=""
+dep_libraries.each do |key, val|
+  str.concat("require(['%s'], function(%s){window['%s']=%s;console.log('finished loading %s');"% Array.new(5, key))
+end
+%>
+<%= str %>
+
+  var script = jquen.select("head")
+      .append("script")
+      .attr("src", "http://code.highcharts.com/highcharts.js")
+      .attr("async", true);
+
+  script[0][0].onload = script[0][0].onreadystatechange = function(){
+<%
+   str=""
+   additional_libraries.each do |key, val|
+   str.concat("require(['%s'], function(%s){window['%s']=%s;console.log('finished loading %s');"% Array.new(5, key))
+   end
+   %>
+<%= str %>
+      var event = document.createEvent("HTMLEvents");
+      event.initEvent("load_highcharts",false,false);
+      window.dispatchEvent(event);
+      console.log('Finished loading highchartsjs');
+<%=
+ str = Array.new(additional_libraries.length, "});").join("")
+%>
+  };
+
+<%
+ str = Array.new(dep_libraries.length, "});").join("")
+%>
+<%= str %>
+}

--- a/lib/templates/init.inline.js.erb
+++ b/lib/templates/init.inline.js.erb
@@ -1,0 +1,17 @@
+if (window['jquery'] === undefined || window['highcharts'] === undefined) {
+  <%
+  all_libraries = dep_libraries.merge(additional_libraries)
+  all_libraries.each do |name, path|
+    basename = File.basename(path)
+    contents = IO.read(File.join(js_dir, basename), mode: 'r:UTF-8')
+  %>
+    /* BEGIN <%= name %>.js */
+<%= contents %>
+    /* END <%= name %>.js */
+  <% end %>
+
+  var event = document.createEvent("HTMLEvents");
+  event.initEvent("load_highcharts", false, false);
+  window.dispatchEvent(event);
+  console.log("Finish loading highchartsjs");
+}


### PR DESCRIPTION
Fixes https://github.com/michelson/lazy_high_charts/issues/235

```
chart = LazyHighCharts::HighChart.new('graph') do |f|
      f.title({ :text=>"Combination chart"})
      f.options[:xAxis][:categories] = ['Apples', 'Oranges', 'Pears', 'Bananas', 'Plums']
      f.labels(:items=>[:html=>"Total fruit consumption", :style=>{:left=>"40px", :top=>"8px", :color=>"black"} ])      
      f.series(:type=> 'column',:name=> 'Jane',:data=> [3, 2, 1, 3, 4])
      f.series(:type=> 'column',:name=> 'John',:data=> [2, 3, 5, 7, 6])
      f.series(:type=> 'column', :name=> 'Joe',:data=> [4, 3, 3, 9, 0])
      f.series(:type=> 'spline',:name=> 'Average', :data=> [3, 2.67, 3, 6.33, 3.33])
      f.series(:type=> 'pie',:name=> 'Total consumption', 
        :data=> [
          {:name=> 'Jane', :y=> 13, :color=> 'red'}, 
          {:name=> 'John', :y=> 23,:color=> 'green'},
          {:name=> 'Joe', :y=> 19,:color=> 'blue'}
        ],
        :center=> [100, 80], :size=> 100, :showInLegend=> false)
    end

include LazyHighCharts::LayoutHelper
IRuby.display high_chart("some_id", chart), mime: 'text/html'
# or
IRuby.html high_chart("some_id", chart).to_s

```

I am not able to understand why `high_chart_iruby("some_id1", chart)` not working. 