### PR TITLE
Add Highcharts 3D to tasks

### DIFF
--- a/lib/tasks/high_charts.rake
+++ b/lib/tasks/high_charts.rake
@@ -17,6 +17,7 @@ namespace :highcharts do
       sh "mkdir -p vendor/assets/javascripts/highcharts/adapters/"
 
       sh "curl -# http://code.highcharts.com/highcharts.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts.js"
+      sh "curl -# http://code.highcharts.com/highcharts-3d.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts-3d.js"
       sh "curl -# http://code.highcharts.com/highcharts-more.js -L --compressed -o vendor/assets/javascripts/highcharts/highcharts-more.js"
 
       # Modules


### PR DESCRIPTION
Add Highcharts 3D to tasks, so we can use '//= require highcharts/highcharts-3d' in application.js. This replicates manual process described in https://github.com/michelson/lazy_high_charts/issues/189