### PR TITLE
Use addEventListener instead of window.onload

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -117,11 +117,9 @@ module LazyHighCharts
       else
         js_output =<<-EOJS
         #{js_start}
-          var onload = window.onload;
-          window.onload = function(){
-            if (typeof onload == "function") onload();
+          window.addEventListener('load', function() {
             #{core_js}
-          };
+          });
         #{js_end}
         EOJS
       end

--- a/spec/lazy_high_charts_spec.rb
+++ b/spec/lazy_high_charts_spec.rb
@@ -65,11 +65,7 @@ describe HighChartsHelper do
       end
 
       it "should assign to the onload event" do
-        expect(high_chart(@placeholder, @chart)).to include('window.onload = function(){')
-      end
-      it "should call any existing onload function" do
-        expect(high_chart(@placeholder, @chart)).to match(/onload = window.onload;/)
-        expect(high_chart(@placeholder, @chart)).to match(/if \(typeof onload == "function"\)\s*onload\(\)/)
+        expect(high_chart(@placeholder, @chart)).to include('window.addEventListener(\'load\', function() {')
       end
     end
     describe "initialize HighChart" do


### PR DESCRIPTION
Use `addEventListener` instead of `window.onload`.

resolves #253 