### PR TITLE
Update event listener setup

### DIFF
--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -117,9 +117,11 @@ module LazyHighCharts
       elsif defined?(Turbo)
         js_output =<<-EOJS
         #{js_start}
-          document.addEventListener("turbo:load", function() {
+          var f = function(){
+            document.removeEventListener('turbo:load', f, true);
             #{core_js}
-          });
+          };
+          document.addEventListener("turbo:load", f, true);
         #{js_end}
         EOJS
       else

--- a/lib/lazy_high_charts/layout_helper.rb
+++ b/lib/lazy_high_charts/layout_helper.rb
@@ -92,53 +92,38 @@ module LazyHighCharts
     end
 
     def encapsulate_js(core_js)
-      if request_is_xhr?
-        js_output = "#{js_start} #{core_js} #{js_end}"
-      # Turbolinks.version < 5
-      elsif defined?(Turbolinks) && request_is_referrer?
-        js_output =<<-EOJS
-        #{js_start}
-          var f = function(){
-            document.removeEventListener('page:load', f, true);
-            #{core_js}
-          };
-          document.addEventListener('page:load', f, true);
-        #{js_end}
-        EOJS
-      # Turbolinks >= 5
-      elsif defined?(Turbolinks) && request_turbolinks_5_tureferrer?
-        js_output =<<-EOJS
-        #{js_start}
-          document.addEventListener("turbolinks:load", function() {
-            #{core_js}
-          });
-        #{js_end}
-        EOJS
-      elsif defined?(Turbo)
-        js_output =<<-EOJS
-        #{js_start}
-          var f = function(){
-            document.removeEventListener('turbo:load', f, true);
-            #{core_js}
-          };
-          document.addEventListener("turbo:load", f, true);
-        #{js_end}
-        EOJS
-      else
-        js_output =<<-EOJS
-        #{js_start}
-          window.addEventListener('load', function() {
-            #{core_js}
-          });
-        #{js_end}
-        EOJS
-      end
+      js_output = if request_is_xhr?
+                    "#{js_start} #{core_js} #{js_end}"
+                  # Turbolinks.version < 5
+                  elsif defined?(Turbolinks) && request_is_referrer?
+                    js_event_function(core_js, 'page:load')
+                  # Turbolinks >= 5
+                  elsif defined?(Turbolinks) && request_turbolinks_5_tureferrer?
+                    js_event_function(core_js, 'turbolinks:load')
+                  # Hotwire Turbo
+                  elsif defined?(Turbo)
+                    js_event_function(core_js, 'turbo:load')
+                  else
+                    js_event_function(core_js, 'load', 'window')
+                  end
 
       if defined?(raw)
         return raw(js_output)
       else
         return js_output
       end
+    end
+
+    def js_event_function(core_js, event, target='document')
+      <<-EOJS
+        #{js_start}
+          var f = function(){
+            #{target}.removeEventListener('#{event}', f, true);
+            #{core_js}
+          };
+          #{target}.addEventListener('#{event}', f, true);
+        #{js_end}
+      EOJS
     end
 
     def js_start


### PR DESCRIPTION
Modifies the non-xhr event listener to ensure that it will only run a single time (initial page load) and not on subsequent page loads unless the event listener is set up again.  This resolves issues where a user would navigate to a page that had high charts in place, and then navigate to another page and get inundated with console errors because the event was attempting to run setup on the charts again with containers that did not exist (or, erroneously get charts set up in containers that should not have them on the new page).

Likewise, it ensures that subsequent page visits to the page that set up the event listener does not set up multiple repetitive event listener events that perform the same action, as the previous set up would add on another duplicate but different event listener to the `document` (or `window` in the case of non-xhr and non-Turbo(links)) element every single time the page was loaded without ever removing any of the old listeners.

Resolves an issue introduced in PR #258 

Resolves #255 
Resolves #223


Supersedes PR #249 
Supersedes PR #224 